### PR TITLE
Fix procman service

### DIFF
--- a/externals/cmake/externals.cmake
+++ b/externals/cmake/externals.cmake
@@ -12,8 +12,11 @@ set(bot_core_lcmtypes_revision c29cd6076d13ca2a3ecc23ffcbe28a0a1ab46314)
 set(bot_core_lcmtypes_depends ${lcm_proj})
 
 set(libbot_url https://github.com/openhumanoids/libbot.git)
-set(libbot_revision ed4a76423f2a21594436490341f907710d3f78dd)
+set(libbot_revision 70b6b4acceae3d18b23f0241b001ddb83ae5a124) #ed4a76423f2a21594436490341f907710d3f78dd)
 set(libbot_depends bot_core_lcmtypes ${lcm_proj})
+set(libbot_external_args
+  CMAKE_CACHE_ARGS ${default_cmake_args} -DWITH_BOT_VIS:BOOL=OFF
+  )
 
 set(externals
   ${lcm_proj}

--- a/externals/cmake/externals.cmake
+++ b/externals/cmake/externals.cmake
@@ -12,12 +12,12 @@ set(bot_core_lcmtypes_revision c29cd6076d13ca2a3ecc23ffcbe28a0a1ab46314)
 set(bot_core_lcmtypes_depends ${lcm_proj})
 
 set(libbot_url https://github.com/openhumanoids/libbot.git)
-set(libbot_revision 70b6b4acceae3d18b23f0241b001ddb83ae5a124) #ed4a76423f2a21594436490341f907710d3f78dd)
+set(libbot_revision 2a243a3) #ed4a76423f2a21594436490341f907710d3f78dd)
 set(libbot_depends bot_core_lcmtypes ${lcm_proj})
 set(libbot_external_args
   CMAKE_CACHE_ARGS
   ${default_cmake_args}
-  -DWITH_BOT_VIS=OFF
+  -DWITH_BOT_VIS:BOOL=OFF
   )
 
 set(externals

--- a/externals/cmake/externals.cmake
+++ b/externals/cmake/externals.cmake
@@ -15,7 +15,9 @@ set(libbot_url https://github.com/openhumanoids/libbot.git)
 set(libbot_revision 70b6b4acceae3d18b23f0241b001ddb83ae5a124) #ed4a76423f2a21594436490341f907710d3f78dd)
 set(libbot_depends bot_core_lcmtypes ${lcm_proj})
 set(libbot_external_args
-  CMAKE_CACHE_ARGS ${default_cmake_args} -DWITH_BOT_VIS:BOOL=OFF
+  CMAKE_CACHE_ARGS
+  ${default_cmake_args}
+  -DWITH_BOT_VIS=OFF
   )
 
 set(externals

--- a/init.d/valkyrie_lcm_distro_bot_procman_deputy
+++ b/init.d/valkyrie_lcm_distro_bot_procman_deputy
@@ -9,8 +9,6 @@
 # Description:       Enable procman-deputy immediately after boot.
 ### END INIT INFO
 
-directory="/home/val/openhumanoids/valkyrie-lcm-distro/build/bin"
-cmd="./bot-procman-deputy -n link"
 user="val"
 
 name=`basename $0`
@@ -33,9 +31,9 @@ start() {
         echo "Starting $name"
         cd "$directory"
         if [ -z "$user" ]; then
-            sudo $cmd >> "$stdout_log" 2>> "$stderr_log" &
+            sudo bash -c 'source ~/.bash_nasa_val && LCM_DEFAULT_URL=udpm://239.255.76.76:7676?ttl=1 bot-procman-deputy -n link' >> "$stdout_log" 2>> "$stderr_log" &
         else
-            sudo -u "$user" $cmd >> "$stdout_log" 2>> "$stderr_log" &
+            sudo -u "$user" bash -c 'source ~/.bash_nasa_val && LCM_DEFAULT_URL=udpm://239.255.76.76:7676?ttl=1 bot-procman-deputy -n link' >> "$stdout_log" 2>> "$stderr_log" &
         fi
         echo $! > "$pid_file"
         if ! is_running; then


### PR DESCRIPTION
Works - a procman is now started with all the required files sourced during boot so that we can use runval/bot-procman-sheriff to start controllers, start the IHMC ROS network processor and to eventually run other commands on link and zelda.

Also now available:

```
alias shutdown_zelda="ssh zelda -t 'sudo shutdown -h now'"
alias shutdown_link="ssh link -t 'sudo shutdown -h now'"
```

**_ToDo before merging:**_
- [ ] revise with proper LCM communities
- [ ] introduce variable for deputy name
- [ ] set procman LCM url `-u`
